### PR TITLE
docs: add agentapi installation prerequisite to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ A Python CLI wrapper for [agentapi](https://github.com/coder/agentapi) that enab
 
 ## Installation
 
+### Prerequisites
+
+cyberian requires [`agentapi`](https://github.com/coder/agentapi) to be installed and available on your PATH. See the [agentapi installation guide](https://github.com/coder/agentapi#installation) for instructions.
+
+### Install cyberian
+
 ```bash
 pip install cyberian
 ```


### PR DESCRIPTION
Add Prerequisites section explaining agentapi dependency

Fixes #7

Generated with [Claude Code](https://claude.ai/code)